### PR TITLE
Add SimpleStorage sample contract

### DIFF
--- a/contracts/SIMPLE_USAGE.md
+++ b/contracts/SIMPLE_USAGE.md
@@ -1,0 +1,18 @@
+# SimpleStorage sample
+
+This folder contains a minimal Solidity sample contract for demonstration and testing: `SimpleStorage.sol`.
+
+How to use (with Hardhat):
+
+1. Compile
+   - npm install
+   - npx hardhat compile
+
+2. Deploy locally (example)
+   - Use a simple Hardhat script or deploy from tests. Example interactive:
+     npx hardhat run --network localhost scripts/deploy.js
+
+3. Interact
+   - Call `store(value)`, `retrieve()`, or `increment()` from tests or scripts.
+
+This sample is intentionally small so it can be used as a starting point for tutorials and unit tests.

--- a/contracts/SimpleStorage.sol
+++ b/contracts/SimpleStorage.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title SimpleStorage sample contract
+/// @notice Minimal example contract for tutorials and tests
+contract SimpleStorage {
+    uint256 private value;
+
+    event Stored(uint256 newValue);
+
+    /// @notice Store a new value
+    /// @param _value The value to store
+    function store(uint256 _value) external {
+        value = _value;
+        emit Stored(_value);
+    }
+
+    /// @notice Retrieve the stored value
+    /// @return The stored uint256 value
+    function retrieve() external view returns (uint256) {
+        return value;
+    }
+
+    /// @notice Increment the stored value by 1
+    function increment() external {
+        value += 1;
+        emit Stored(value);
+    }
+}


### PR DESCRIPTION
Adds a minimal SimpleStorage Solidity contract (contracts/SimpleStorage.sol) and usage notes (contracts/SIMPLE_USAGE.md) for tutorial/testing purposes.